### PR TITLE
Migrate `logging_utils` from `qutip` to `qutip_qtrl`

### DIFF
--- a/src/qutip_qtrl/dynamics.py
+++ b/src/qutip_qtrl/dynamics.py
@@ -43,7 +43,7 @@ import qutip_qtrl.symplectic as sympl
 import qutip_qtrl.dump as qtrldump
 
 # QuTiP logging
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/fidcomp.py
+++ b/src/qutip_qtrl/fidcomp.py
@@ -36,7 +36,7 @@ from qutip import Qobj
 import qutip_qtrl.errors as errors
 
 # QuTiP logging
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/loadparams.py
+++ b/src/qutip_qtrl/loadparams.py
@@ -19,7 +19,7 @@ from configparser import ConfigParser
 
 # QuTiP logging
 from qutip import Qobj
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/logging_utils.py
+++ b/src/qutip_qtrl/logging_utils.py
@@ -20,7 +20,7 @@ WARN = logging.WARN
 ERROR = logging.ERROR
 CRITICAL = logging.CRITICAL
 
-__all__ = ['get_logger']
+__all__ = ["get_logger"]
 
 # META-LOGGING
 
@@ -29,6 +29,7 @@ metalogger.addHandler(logging.NullHandler())
 
 
 # FUNCTIONS
+
 
 def get_logger(name=None):
     """
@@ -53,26 +54,29 @@ def get_logger(name=None):
         try:
             calling_frame = inspect.stack()[1][0]
             calling_module = inspect.getmodule(calling_frame)
-            name = (calling_module.__name__
-                    if calling_module is not None else '<none>')
+            name = (
+                calling_module.__name__
+                if calling_module is not None
+                else "<none>"
+            )
 
         except Exception:
-            metalogger.warn('Error creating logger.', exc_info=1)
-            name = '<unknown>'
+            metalogger.warn("Error creating logger.", exc_info=1)
+            name = "<unknown>"
 
     logger = logging.getLogger(name)
 
     policy = settings.log_handler
 
-    if policy == 'default':
+    if policy == "default":
         # Let's try to see if we're in IPython mode.
-        policy = 'basic' if settings.ipython else 'stream'
+        policy = "basic" if settings.ipython else "stream"
 
-    metalogger.debug("Creating logger for {} with policy {}.".format(
-        name, policy
-    ))
+    metalogger.debug(
+        "Creating logger for {} with policy {}.".format(name, policy)
+    )
 
-    if policy == 'basic':
+    if policy == "basic":
         # Add no handlers, just let basicConfig do it all.
         # This is nice for working with IPython, since
         # it will use its own handlers instead of our StreamHandler
@@ -82,11 +86,12 @@ def get_logger(name=None):
         else:
             logging.basicConfig()
 
-    elif policy == 'stream':
+    elif policy == "stream":
         formatter = logging.Formatter(
-            '[%(asctime)s] %(name)s[%(process)s]: '
-            '%(funcName)s: %(levelname)s: %(message)s',
-            '%Y-%m-%d %H:%M:%S')
+            "[%(asctime)s] %(name)s[%(process)s]: "
+            "%(funcName)s: %(levelname)s: %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
         logger.addHandler(handler)
@@ -94,7 +99,7 @@ def get_logger(name=None):
         # We're handling things here, so no propagation out.
         logger.propagate = False
 
-    elif policy == 'null':
+    elif policy == "null":
         # We need to add a NullHandler so that debugging works
         # at all, but this policy leaves it to the user to
         # make their own handlers. This is particularly useful

--- a/src/qutip_qtrl/logging_utils.py
+++ b/src/qutip_qtrl/logging_utils.py
@@ -1,0 +1,109 @@
+"""
+This module contains internal-use functions for configuring and writing to
+debug logs, using Python's internal logging functionality by default.
+"""
+
+# IMPORTS
+from __future__ import absolute_import
+import inspect
+import logging
+
+from qutip.settings import settings
+
+# EXPORTS
+NOTSET = logging.NOTSET
+DEBUG_INTENSE = logging.DEBUG - 4
+DEBUG_VERBOSE = logging.DEBUG - 2
+DEBUG = logging.DEBUG
+INFO = logging.INFO
+WARN = logging.WARN
+ERROR = logging.ERROR
+CRITICAL = logging.CRITICAL
+
+__all__ = ['get_logger']
+
+# META-LOGGING
+
+metalogger = logging.getLogger(__name__)
+metalogger.addHandler(logging.NullHandler())
+
+
+# FUNCTIONS
+
+def get_logger(name=None):
+    """
+    Returns a Python logging object with handlers configured
+    in accordance with ~/.qutiprc. By default, this will do
+    something sensible to integrate with IPython when running
+    in that environment, and will print to stdout otherwise.
+
+    Note that this function uses a bit of magic, and thus should
+    not be considered part of the QuTiP API. Rather, this function
+    is for internal use only.
+
+    Parameters
+    ----------
+
+    name : str
+        Name of the logger to be created. If not passed,
+        the name will automatically be set to the name of the
+        calling module.
+    """
+    if name is None:
+        try:
+            calling_frame = inspect.stack()[1][0]
+            calling_module = inspect.getmodule(calling_frame)
+            name = (calling_module.__name__
+                    if calling_module is not None else '<none>')
+
+        except Exception:
+            metalogger.warn('Error creating logger.', exc_info=1)
+            name = '<unknown>'
+
+    logger = logging.getLogger(name)
+
+    policy = settings.log_handler
+
+    if policy == 'default':
+        # Let's try to see if we're in IPython mode.
+        policy = 'basic' if settings.ipython else 'stream'
+
+    metalogger.debug("Creating logger for {} with policy {}.".format(
+        name, policy
+    ))
+
+    if policy == 'basic':
+        # Add no handlers, just let basicConfig do it all.
+        # This is nice for working with IPython, since
+        # it will use its own handlers instead of our StreamHandler
+        # below.
+        if settings.debug:
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig()
+
+    elif policy == 'stream':
+        formatter = logging.Formatter(
+            '[%(asctime)s] %(name)s[%(process)s]: '
+            '%(funcName)s: %(levelname)s: %(message)s',
+            '%Y-%m-%d %H:%M:%S')
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        # We're handling things here, so no propagation out.
+        logger.propagate = False
+
+    elif policy == 'null':
+        # We need to add a NullHandler so that debugging works
+        # at all, but this policy leaves it to the user to
+        # make their own handlers. This is particularly useful
+        # for capturing to logfiles.
+        logger.addHandler(logging.NullHandler())
+
+    if settings.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARN)
+
+    return logger

--- a/src/qutip_qtrl/optimizer.py
+++ b/src/qutip_qtrl/optimizer.py
@@ -74,7 +74,7 @@ import qutip_qtrl.dynamics as dynamics
 import qutip_qtrl.pulsegen as pulsegen
 import qutip_qtrl.dump as qtrldump
 
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/propcomp.py
+++ b/src/qutip_qtrl/propcomp.py
@@ -27,7 +27,7 @@ from qutip import Qobj
 from qutip_qtrl import errors
 
 # QuTiP logging
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -17,7 +17,7 @@ import numpy as np
 import qutip_qtrl.dynamics as dynamics
 import qutip_qtrl.errors as errors
 
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -71,7 +71,7 @@ import qutip_qtrl.errors as errors
 import qutip_qtrl.fidcomp as fidcomp
 import qutip_qtrl.propcomp as propcomp
 import qutip_qtrl.pulsegen as pulsegen
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 

--- a/src/qutip_qtrl/tslotcomp.py
+++ b/src/qutip_qtrl/tslotcomp.py
@@ -44,7 +44,7 @@ import qutip_qtrl.errors as errors
 import qutip_qtrl.dump as qtrldump
 
 # QuTiP logging
-import qutip.logging_utils as logging
+import qutip_qtrl.logging_utils as logging
 
 logger = logging.get_logger()
 


### PR DESCRIPTION
`logging_utils` is no longer used in qutip,  only here.
This migrate the file here.