### PR TITLE
Use qutip_qtrl.logging_utils instead of qutip.logging_utils

### DIFF
--- a/src/qutip_qtrl/dump.py
+++ b/src/qutip_qtrl/dump.py
@@ -17,9 +17,9 @@ from numpy.compat import asbytes
 import qutip_qtrl.io as qtrlio
 
 # QuTiP logging
-import qutip.logging_utils
+import qutip_qtrl.logging_utils
 
-logger = qutip.logging_utils.get_logger("qutip.control.dump")
+logger = qutip_qtrl.logging_utils.get_logger("qutip.control.dump")
 
 DUMP_DIR = "~/.qtrl_dump"
 

--- a/src/qutip_qtrl/dynamics.py
+++ b/src/qutip_qtrl/dynamics.py
@@ -135,7 +135,7 @@ class Dynamics(object):
     ----------
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,

--- a/src/qutip_qtrl/fidcomp.py
+++ b/src/qutip_qtrl/fidcomp.py
@@ -80,7 +80,7 @@ class FidelityComputer(object):
     ----------
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,

--- a/src/qutip_qtrl/grape.py
+++ b/src/qutip_qtrl/grape.py
@@ -20,9 +20,9 @@ from qutip.core import data as _data
 from qutip.ui.progressbar import BaseProgressBar
 from qutip_qtrl.cy_grape import cy_overlap, cy_grape_inner
 
-import qutip.logging_utils
+import qutip_qtrl.logging_utils
 
-logger = qutip.logging_utils.get_logger("qutip.control.grape")
+logger = qutip_qtrl.logging_utils.get_logger("qutip.control.grape")
 
 
 class GRAPEResult:

--- a/src/qutip_qtrl/optimconfig.py
+++ b/src/qutip_qtrl/optimconfig.py
@@ -12,9 +12,9 @@ Configuration parameters for control pulse optimisation
 import numpy as np
 
 # QuTiP logging
-import qutip.logging_utils
+import qutip_qtrl.logging_utils
 
-logger = qutip.logging_utils.get_logger("qutip.control.optimconfig")
+logger = qutip_qtrl.logging_utils.get_logger("qutip.control.optimconfig")
 import qutip_qtrl.io as qtrlio
 
 
@@ -26,7 +26,7 @@ class OptimConfig(object):
     ----------
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,

--- a/src/qutip_qtrl/optimizer.py
+++ b/src/qutip_qtrl/optimizer.py
@@ -128,7 +128,7 @@ class Optimizer(object):
     ----------
     log_level : integer
         level of messaging output from the logger.  Options are attributes of
-        qutip.logging_utils, in decreasing levels of messaging, are:
+        qutip_qtrl.logging_utils, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution, assuming
         everything runs as expected.  The default NOTSET implies that the level

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -140,7 +140,7 @@ class PulseGen:
 
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -331,7 +331,7 @@ def optimize_pulse(
 
     log_level : integer
         Level of messaging output from the logger.  Options are attributes of
-        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
+        :obj:`qutip_qtrl.logging_utils`, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL.
         Anything WARN or above is effectively 'quiet' execution, assuming
         everything runs as expected.  The default NOTSET implies that the level
@@ -740,7 +740,7 @@ def optimize_pulse_unitary(
 
     log_level : integer
         Level of messaging output from the logger.  Options are attributes of
-        :obj:`qutip.logging_utils` in decreasing levels of messaging, are:
+        :obj:`qutip_qtrl.logging_utils` in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution, assuming
         everything runs as expected.  The default NOTSET implies that the level
@@ -1069,7 +1069,7 @@ def opt_pulse_crab(
 
     log_level : integer
         level of messaging output from the logger.  Options are attributes of
-        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
+        :obj:`qutip_qtrl.logging_utils`, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution, assuming
         everything runs as expected.  The default NOTSET implies that the level
@@ -1382,7 +1382,7 @@ def opt_pulse_crab_unitary(
 
     log_level : integer
         Level of messaging output from the logger.  Options are attributes of
-        :obj:`qutip.logging_utils`, in decreasing levels of messaging, are:
+        :obj:`qutip_qtrl.logging_utils`, in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL.
         Anything WARN or above is effectively 'quiet' execution, assuming
         everything runs as expected.  The default NOTSET implies that the level
@@ -1727,7 +1727,7 @@ def create_pulse_optimizer(
 
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,

--- a/src/qutip_qtrl/tslotcomp.py
+++ b/src/qutip_qtrl/tslotcomp.py
@@ -68,7 +68,7 @@ class TimeslotComputer:
     ----------
     log_level : integer
         level of messaging output from the logger.
-        Options are attributes of qutip.logging_utils,
+        Options are attributes of qutip_qtrl.logging_utils,
         in decreasing levels of messaging, are:
         DEBUG_INTENSE, DEBUG_VERBOSE, DEBUG, INFO, WARN, ERROR, CRITICAL
         Anything WARN or above is effectively 'quiet' execution,


### PR DESCRIPTION
Some part of `qutip_qtrl` is still using the `qutip.logging_util`. Remove them.