### PR TITLE
Add frequencies as optional CRAB parameter

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,5 +86,5 @@ bibtex_default_style = "unsrt"
 # -- Options for intersphinx ---------------------------------------
 
 intersphinx_mapping = {
-    "qutip": ("https://qutip.org/docs/latest/", None),
+    "qutip": ("https://qutip.readthedocs.io/en/latest/", None),
 }

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1054,6 +1054,7 @@ class PulseGenCrab(PulseGen):
             of the same name.
         init_coeffs : float array[num_coeffs * num_basis_funcs]
             Typically this will be the initial basis coefficients.
+            If set to `None` (the default), the initial coefficients will be automatically generated.
         """
         if num_coeffs:
             self.num_coeffs = num_coeffs

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1300,7 +1300,7 @@ class PulseGenCrabFourier(PulseGenCrab):
         pulse = np.zeros(self.num_tslots)
 
         for i in range(self.num_coeffs):
-            if self.fix_freqs: # dont optimise frequencies
+            if self.fix_freqs:  # dont optimise frequencies
                 phase = self.freqs[i] * self.time
             else:  # optimise frequencies as part of the parameters
                 phase = self.coeffs[i, 2] * self.time

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1017,13 +1017,13 @@ class PulseGenCrab(PulseGen):
         self.guess_pulse_func = None
         self.apply_params()
 
-    def init_pulse(self, num_coeffs=None, init_param_vals=None):
+    def init_pulse(self, num_coeffs=None, init_coeffs=None):
         """
         Set the initial freq and coefficient values
         """
         PulseGen.init_pulse(self)
         self.init_coeffs(
-            num_coeffs=num_coeffs, init_param_vals=init_param_vals
+            num_coeffs=num_coeffs, init_coeffs=init_coeffs
         )
 
         if self.guess_pulse is not None:
@@ -1044,7 +1044,7 @@ class PulseGenCrab(PulseGen):
     #            self.guess_pulse = self.guess_pulsegen.gen_pulse()
     #        return self.guess_pulse
 
-    def init_coeffs(self, num_coeffs=None, init_param_vals=None):
+    def init_coeffs(self, num_coeffs=None, init_coeffs=None):
         """
         Generate or set the initial ceofficent values.
 
@@ -1054,7 +1054,7 @@ class PulseGenCrab(PulseGen):
             Number of coefficients used for each basis function
             If given this overides the default and sets the attribute
             of the same name.
-        init_param_vals : float array[num_coeffs * num_basis_funcs]
+        init_coeffs : float array[num_coeffs * num_basis_funcs]
             Typically this will be the initial basis coefficients.
         """
         if num_coeffs:
@@ -1091,8 +1091,8 @@ class PulseGenCrab(PulseGen):
                             self.num_coeffs, self.NUM_COEFFS_WARN_LVL
                         )
                     )
-        if init_param_vals is not None:
-            self.set_coeffs(init_param_vals)
+        if init_coeffs is not None:
+            self.set_coeffs(init_coeffs)
         elif self.randomize_coeffs:
             r = np.random.random([self.num_coeffs, self.num_basis_funcs])
             self.coeffs = (2 * r - 1.0) * self.scaling
@@ -1263,12 +1263,12 @@ class PulseGenCrabFourier(PulseGenCrab):
         self.freqs = None
         self.randomize_freqs = True
 
-    def init_pulse(self, num_coeffs=None, init_param_vals=None):
+    def init_pulse(self, num_coeffs=None, init_coeffs=None):
         """
         Set the initial freq and coefficient values
         """
         PulseGenCrab.init_pulse(
-            self, num_coeffs=num_coeffs, init_param_vals=init_param_vals
+            self, num_coeffs=num_coeffs, init_coeffs=init_coeffs
         )
 
         self.init_freqs()

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1022,9 +1022,7 @@ class PulseGenCrab(PulseGen):
         Set the initial freq and coefficient values
         """
         PulseGen.init_pulse(self)
-        self.init_coeffs(
-            num_coeffs=num_coeffs, init_coeffs=init_coeffs
-        )
+        self.init_coeffs(num_coeffs=num_coeffs, init_coeffs=init_coeffs)
 
         if self.guess_pulse is not None:
             self.init_guess_pulse()

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1067,6 +1067,10 @@ class PulseGenCrab(PulseGen):
                 self.num_coeffs = self.DEF_NUM_COEFFS
         self.num_optim_vars = self.num_coeffs * self.num_basis_funcs
 
+        # Only generate coefficients if they have not been set yet
+        if self.coeffs is not None:
+            return
+
         if self._num_coeffs_estimated:
             if self.log_level <= logging.INFO:
                 logger.info(

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -988,10 +988,11 @@ class PulseGenCrab(PulseGen):
         when initialised, otherwise they will all be equal to self.scaling
     """
 
-    def __init__(self, dyn=None, num_coeffs=None, params=None):
+    def __init__(self, dyn=None, num_coeffs=None, params=None, fix_freqs=True):
         self.parent = dyn
         self.num_coeffs = num_coeffs
         self.params = params
+        self.fix_freqs = fix_freqs
         self.reset()
 
     def reset(self):
@@ -1007,7 +1008,7 @@ class PulseGenCrab(PulseGen):
 
         self._uses_time = True
         self.time = None
-        self.num_basis_funcs = 2
+        self.num_basis_funcs = 2 if self.fix_freqs else 3
         self.num_optim_vars = 0
         self.coeffs = None
         self.randomize_coeffs = True
@@ -1289,7 +1290,10 @@ class PulseGenCrabFourier(PulseGenCrab):
         pulse = np.zeros(self.num_tslots)
 
         for i in range(self.num_coeffs):
-            phase = self.freqs[i] * self.time
+            if self.fix_freqs:
+                phase = self.freqs[i] * self.time
+            else: # optimise frequencies as part of the parameters
+                phase = self.coeffs[i, 2] * self.time
             pulse += self.coeffs[i, 0] * np.sin(phase) + self.coeffs[
                 i, 1
             ] * np.cos(phase)

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1267,7 +1267,9 @@ class PulseGenCrabFourier(PulseGenCrab):
         """
         Set the initial freq and coefficient values
         """
-        PulseGenCrab.init_pulse(self, init_param_vals=init_param_vals)
+        PulseGenCrab.init_pulse(
+            self, num_coeffs=num_coeffs, init_param_vals=init_param_vals
+        )
 
         self.init_freqs()
 

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -986,6 +986,12 @@ class PulseGenCrab(PulseGen):
     randomize_coeffs : bool
         If True (default) then the coefficients are set to some random values
         when initialised, otherwise they will all be equal to self.scaling
+
+    fix_freqs : bool
+        If True (default) then the frequencies of the basis functions are fixed
+        and the number of basis functions is set to 2. Otherwise the
+        frequencies are also optimised and the number of basis functions
+        becomes 3.
     """
 
     def __init__(self, dyn=None, num_coeffs=None, params=None, fix_freqs=True):
@@ -1294,7 +1300,7 @@ class PulseGenCrabFourier(PulseGenCrab):
         pulse = np.zeros(self.num_tslots)
 
         for i in range(self.num_coeffs):
-            if self.fix_freqs:
+            if self.fix_freqs: # dont optimise frequencies
                 phase = self.freqs[i] * self.time
             else:  # optimise frequencies as part of the parameters
                 phase = self.coeffs[i, 2] * self.time

--- a/src/qutip_qtrl/pulsegen.py
+++ b/src/qutip_qtrl/pulsegen.py
@@ -1292,7 +1292,7 @@ class PulseGenCrabFourier(PulseGenCrab):
         for i in range(self.num_coeffs):
             if self.fix_freqs:
                 phase = self.freqs[i] * self.time
-            else: # optimise frequencies as part of the parameters
+            else:  # optimise frequencies as part of the parameters
                 phase = self.coeffs[i, 2] * self.time
             pulse += self.coeffs[i, 0] * np.sin(phase) + self.coeffs[
                 i, 1

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -2020,9 +2020,11 @@ def create_pulse_optimizer(
         # Create a pulse generator for each ctrl
         crab_pulse_params = None
         num_coeffs = None
+        fix_freqs = True
         init_coeff_scaling = None
         if isinstance(alg_params, dict):
             num_coeffs = alg_params.get("num_coeffs")
+            fix_freqs = alg_params.get("fix_frequency")
             init_coeff_scaling = alg_params.get("init_coeff_scaling")
             if "crab_pulse_params" in alg_params:
                 crab_pulse_params = alg_params.get("crab_pulse_params")
@@ -2044,7 +2046,7 @@ def create_pulse_optimizer(
             crab_pgen = pulsegen.PulseGenCrabFourier(
                 dyn=dyn,
                 num_coeffs=num_coeffs,
-                fix_freqs=alg_params.get("fix_frequency", True),
+                fix_freqs=fix_freqs,
             )
             if init_coeff_scaling is not None:
                 crab_pgen.scaling = init_coeff_scaling

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -2024,7 +2024,7 @@ def create_pulse_optimizer(
         init_coeff_scaling = None
         if isinstance(alg_params, dict):
             num_coeffs = alg_params.get("num_coeffs")
-            fix_freqs = alg_params.get("fix_frequency")
+            fix_freqs = alg_params.get("fix_frequency", True)
             init_coeff_scaling = alg_params.get("init_coeff_scaling")
             if "crab_pulse_params" in alg_params:
                 crab_pulse_params = alg_params.get("crab_pulse_params")

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -2042,8 +2042,9 @@ def create_pulse_optimizer(
         optim.pulse_generator = []
         for j in range(n_ctrls):
             crab_pgen = pulsegen.PulseGenCrabFourier(
-                dyn=dyn, num_coeffs=num_coeffs,
-                fix_freqs=alg_params.get("fix_frequency", True)
+                dyn=dyn,
+                num_coeffs=num_coeffs,
+                fix_freqs=alg_params.get("fix_frequency", True),
             )
             if init_coeff_scaling is not None:
                 crab_pgen.scaling = init_coeff_scaling

--- a/src/qutip_qtrl/pulseoptim.py
+++ b/src/qutip_qtrl/pulseoptim.py
@@ -2042,7 +2042,8 @@ def create_pulse_optimizer(
         optim.pulse_generator = []
         for j in range(n_ctrls):
             crab_pgen = pulsegen.PulseGenCrabFourier(
-                dyn=dyn, num_coeffs=num_coeffs
+                dyn=dyn, num_coeffs=num_coeffs,
+                fix_freqs=alg_params.get("fix_frequency", True)
             )
             if init_coeff_scaling is not None:
                 crab_pgen.scaling = init_coeff_scaling

--- a/tests/test_control_pulseoptim.py
+++ b/tests/test_control_pulseoptim.py
@@ -667,3 +667,26 @@ class TestTimeDependence:
             np.testing.assert_allclose(
                 result.initial_amps[k], result.final_amps[k], rtol=1e-9
             )
+
+
+def test_init_pulsegencrab():
+    """
+    Test the initialization of CRAB Fourier parameters
+    """
+    # Setup pulse generator
+    config = qutip_qtrl.optimconfig.OptimConfig()
+    dyn = cpo.dynamics.Dynamics(config)
+    crab_pgen = cpo.pulsegen.PulseGenCrabFourier(
+        dyn=dyn,
+        num_coeffs=1,
+        fix_freqs=False,
+    )
+    # Initialize pulsegenerator
+    vals = np.array([1, 1, 1])
+    crab_pgen.init_pulse(init_param_vals=vals)
+    init_amps = crab_pgen.gen_pulse()
+    # Check initial pulse
+    pulse = vals[0] * np.sin(vals[2] * crab_pgen.time) + vals[1] * np.cos(
+        vals[2] * crab_pgen.time
+    )
+    assert np.isclose(init_amps, pulse).all()

--- a/tests/test_control_pulseoptim.py
+++ b/tests/test_control_pulseoptim.py
@@ -410,6 +410,40 @@ class TestOptimization:
         assert abs(result.fid_err) < tol
         assert abs(result.final_amps[0, 0]) < tol, "Lead-in amplitude nonzero."
 
+    def test_init_pulsegencrab(self, system, propagation):
+        """
+        Test the initialization of CRAB Fourier parameters
+        """
+        # Setup the optimizer
+        system = _merge_kwargs(system, propagation)
+        optimizer = cpo.create_pulse_optimizer(
+            system.system,
+            system.controls,
+            system.initial,
+            system.target,
+            alg="CRAB",
+            **system.kwargs,
+        )
+        dynamics = optimizer.dynamics
+
+        init_amps = np.zeros([dynamics.num_tslots, dynamics.num_ctrls])
+        # Generate initial pulses for each control through generator
+        for i, pgen in enumerate(optimizer.pulse_generator):
+            num_coeffs = 8
+            vals = np.ones(num_coeffs * pgen.num_basis_funcs)
+            pgen.init_pulse(num_coeffs, init_param_vals=vals)
+            init_amps[:, i] = pgen.gen_pulse()
+
+        # Initialize the dynamics with the initial amplitudes
+        dynamics.initialize_controls(init_amps)
+
+        # Run the optimization
+        result = optimizer.run_optimization()
+        assert isinstance(result.fid_err, float)
+
+        # Check proper initialization of CRAB amplitudes
+        assert np.isclose(result.initial_amps, init_amps).all()
+
 
 # The full object-orientated interface to the optimiser is rather complex.  To
 # attempt to simplify the test of the configuration loading, we break it down
@@ -667,26 +701,3 @@ class TestTimeDependence:
             np.testing.assert_allclose(
                 result.initial_amps[k], result.final_amps[k], rtol=1e-9
             )
-
-
-def test_init_pulsegencrab():
-    """
-    Test the initialization of CRAB Fourier parameters
-    """
-    # Setup pulse generator
-    config = qutip_qtrl.optimconfig.OptimConfig()
-    dyn = cpo.dynamics.Dynamics(config)
-    crab_pgen = cpo.pulsegen.PulseGenCrabFourier(
-        dyn=dyn,
-        num_coeffs=1,
-        fix_freqs=False,
-    )
-    # Initialize pulsegenerator
-    vals = np.array([1, 1, 1])
-    crab_pgen.init_pulse(init_param_vals=vals)
-    init_amps = crab_pgen.gen_pulse()
-    # Check initial pulse
-    pulse = vals[0] * np.sin(vals[2] * crab_pgen.time) + vals[1] * np.cos(
-        vals[2] * crab_pgen.time
-    )
-    assert np.isclose(init_amps, pulse).all()

--- a/tests/test_control_pulseoptim.py
+++ b/tests/test_control_pulseoptim.py
@@ -431,7 +431,7 @@ class TestOptimization:
         for i, pgen in enumerate(optimizer.pulse_generator):
             num_coeffs = 8
             vals = np.ones(num_coeffs * pgen.num_basis_funcs)
-            pgen.init_pulse(num_coeffs, init_param_vals=vals)
+            pgen.init_pulse(num_coeffs, init_coeffs=vals)
             init_amps[:, i] = pgen.gen_pulse()
 
         # Initialize the dynamics with the initial amplitudes


### PR DESCRIPTION
This PR introduces variable Fourier frequencies for the CRAB algorith.
So far they were fixed. This is still the default behaviour and all additional parameters are optional (no breaking changes).
Recently a user requested to provide initial starting values for all parameters. With this PR it can be done in the new QOC package.