### PR TITLE
Bugfix for method_params

### DIFF
--- a/src/qutip_qtrl/optimizer.py
+++ b/src/qutip_qtrl/optimizer.py
@@ -484,7 +484,7 @@ class Optimizer(object):
                 val = params[key]
                 if hasattr(self, key):
                     setattr(self, key, val)
-                if hasattr(self.termination_conditions, key):
+                elif hasattr(self.termination_conditions, key):
                     setattr(self.termination_conditions, key, val)
                 else:
                     unused_params[key] = val


### PR DESCRIPTION
If a user specifies their own `method_params` for an optimizer, they are set correctly as the optimizer's attributes.
However, because of an `elif` mistake, the parameter was added to the `unused_params` dictionary even if they were used!
This leads to an error where we can have the same argument passed multiple times to `spopt.minimize` through the `method_options` argument.