### PR TITLE
Use the correct setting attributes

### DIFF
--- a/src/qutip_qtrl/logging_utils.py
+++ b/src/qutip_qtrl/logging_utils.py
@@ -66,7 +66,7 @@ def get_logger(name=None):
 
     logger = logging.getLogger(name)
 
-    policy = settings.log_handler
+    policy = settings._log_handler
 
     if policy == "default":
         # Let's try to see if we're in IPython mode.
@@ -81,7 +81,7 @@ def get_logger(name=None):
         # This is nice for working with IPython, since
         # it will use its own handlers instead of our StreamHandler
         # below.
-        if settings.debug:
+        if settings._debug:
             logging.basicConfig(level=logging.DEBUG)
         else:
             logging.basicConfig()
@@ -106,7 +106,7 @@ def get_logger(name=None):
         # for capturing to logfiles.
         logger.addHandler(logging.NullHandler())
 
-    if settings.debug:
+    if settings._debug:
         logger.setLevel(logging.DEBUG)
     else:
         logger.setLevel(logging.WARN)


### PR DESCRIPTION
The qutip setting attributes for log_handler and debug have long become private.
https://github.com/qutip/qutip/blob/487e4ec416def10caff8683ff5ca0fc8779e79cb/qutip/settings.py#L133-L134

I don't really understand why it was working before but now it starts to raise errors **if qutip is built from the master branch**.
fix #22