### PR TITLE
Add QuTiP family entry point.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,10 @@ setup_requires =
 [options.packages.find]
 where = src
 
+[options.entry_points]
+qutip.family =
+    qutip_qtrl = qutip_qtrl.family
+
 [options.extras_require]
 tests =
     pytest>=5.2

--- a/src/qutip_qtrl/family.py
+++ b/src/qutip_qtrl/family.py
@@ -1,0 +1,8 @@
+"""QuTiP family package entry point."""
+
+from . import __version__
+
+
+def version():
+    """Return information to include in qutip.about()."""
+    return "qutip-qtrl", __version__

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -1,0 +1,12 @@
+"""Tests for qutip_qtrl.family."""
+
+import re
+
+from qutip_qtrl import family
+
+
+class TestVersion:
+    def test_version(self):
+        pkg, version = family.version()
+        assert pkg == "qutip-qtrl"
+        assert re.match(r"\d+\.\d+\.\d+.*", version)


### PR DESCRIPTION
This adds the `qutip.about()` entry point for qutip-qtrl.